### PR TITLE
Use Dir.tmpdir to get the OS temporary path

### DIFF
--- a/composite.rb
+++ b/composite.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'rmagick'
+require 'tmpdir'
 
 module Composite
 
@@ -14,7 +15,7 @@ module Composite
 
   def self.generate_image source, name, id
     # puts "Generating image for #{name}"
-    output_name = "tmp/#{id}_#{name}.png"
+    output_name = "#{Dir.tmpdir}/#{id}_#{name}.png"
 
     # `textorize -fYou2013 -gtransparent -s55 -cwhite -o#{output_name} #{name}`
     `convert -background transparent -fill white -font you_db-webfont.ttf -pointsize 55 label:#{name} #{output_name}`
@@ -29,7 +30,7 @@ module Composite
 
     coordinates = Composite.center(name_img.columns, name_img.rows)
     bottle = bottle.composite(name_img, coordinates[0], coordinates[1], Magick::OverCompositeOp)
-    final = "tmp/#{id}_#{name}_final.png"
+    final = "#{Dir.tmpdir}/#{id}_#{name}_final.png"
     bottle.write(final)
     sleep(0.5)
     final


### PR DESCRIPTION
When I tried it, the script fails with a `WriteBlob` error message due to the wrong temp directory path.
Using `Dir.tmpdir` instead of hardcoding `tmp` avoid building paths manually, reducing the possibility of such an error and leaves Ruby to make decisions on where to place the temp files, enabling the app to work better across multiple OS's
